### PR TITLE
Export `getSemiMajorAxis` functions for planets

### DIFF
--- a/src/planets/jupiter/index.ts
+++ b/src/planets/jupiter/index.ts
@@ -36,7 +36,8 @@ import {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
-  getMeanLongitude
+  getMeanLongitude,
+  getSemiMajorAxis
 } from './orbital'
 import {
   getCentralMeridianLongitudes,
@@ -70,6 +71,7 @@ export const Jupiter: JupiterPlanet = {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
+  getSemiMajorAxis,
   // Planet base properties
   getAphelion,
   getPerihelion,

--- a/src/planets/mars/index.ts
+++ b/src/planets/mars/index.ts
@@ -36,7 +36,8 @@ import {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
-  getMeanLongitude
+  getMeanLongitude,
+  getSemiMajorAxis
 } from './orbital'
 import { getPlanetocentricDeclinationOfTheEarth, getPlanetocentricDeclinationOfTheSun } from './specific'
 
@@ -66,6 +67,7 @@ export const Mars: MarsPlanet = {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
+  getSemiMajorAxis,
   // Planet base properties
   getAphelion,
   getPerihelion,

--- a/src/planets/mercury/index.ts
+++ b/src/planets/mercury/index.ts
@@ -36,7 +36,8 @@ import {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
-  getMeanLongitude
+  getMeanLongitude,
+  getSemiMajorAxis
 } from './orbital'
 
 export const Mercury: Planet = {
@@ -65,6 +66,7 @@ export const Mercury: Planet = {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
+  getSemiMajorAxis,
   // Planet base properties
   getAphelion,
   getPerihelion,

--- a/src/planets/neptune/index.ts
+++ b/src/planets/neptune/index.ts
@@ -36,7 +36,8 @@ import {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
-  getMeanLongitude
+  getMeanLongitude,
+  getSemiMajorAxis
 } from './orbital'
 
 export const Neptune: Planet = {
@@ -65,6 +66,7 @@ export const Neptune: Planet = {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
+  getSemiMajorAxis,
   // Planet base properties
   getAphelion,
   getPerihelion,

--- a/src/planets/saturn/index.ts
+++ b/src/planets/saturn/index.ts
@@ -36,7 +36,8 @@ import {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
-  getMeanLongitude
+  getMeanLongitude,
+  getSemiMajorAxis
 } from './orbital'
 import { getRingSystemDetails } from './ringSystem'
 
@@ -66,6 +67,7 @@ export const Saturn: SaturnPlanet = {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
+  getSemiMajorAxis,
   // Planet base properties
   getAphelion,
   getPerihelion,

--- a/src/planets/uranus/index.ts
+++ b/src/planets/uranus/index.ts
@@ -36,7 +36,8 @@ import {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
-  getMeanLongitude
+  getMeanLongitude,
+  getSemiMajorAxis
 } from './orbital'
 
 export const Uranus: Planet = {
@@ -65,6 +66,7 @@ export const Uranus: Planet = {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
+  getSemiMajorAxis,
   // Planet base properties
   getAphelion,
   getPerihelion,

--- a/src/planets/venus/index.ts
+++ b/src/planets/venus/index.ts
@@ -36,7 +36,8 @@ import {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
-  getMeanLongitude
+  getMeanLongitude,
+  getSemiMajorAxis
 } from './orbital'
 
 export const Venus: Planet = {
@@ -65,6 +66,7 @@ export const Venus: Planet = {
   getInclination,
   getLongitudeOfAscendingNode,
   getLongitudeOfPerihelion,
+  getSemiMajorAxis,
   // Planet base properties
   getAphelion,
   getPerihelion,

--- a/src/types/planets.ts
+++ b/src/types/planets.ts
@@ -97,6 +97,7 @@ export interface Planet extends PlanetBase {
   getInclination: QuantityInDegreeAtJulianDayFunction
   getLongitudeOfAscendingNode: QuantityInDegreeAtJulianDayFunction
   getLongitudeOfPerihelion: QuantityInDegreeAtJulianDayFunction
+  getSemiMajorAxis: QuantityInDegreeAtJulianDayFunction
   // Extended planet base properties (details.ts)
   getAphelion: JulianDayForJulianDayFunction
   getPerihelion: JulianDayForJulianDayFunction


### PR DESCRIPTION
While using this package, I noticed that currently the `getSemiMajorAxis` functions for the planets are not exported from the packages, which I suspect is not intentional since they are mentioned in the documentation for the planet modules. This PR updates the planet index files to export these functions.