### PR TITLE
Update typing for a few planet functions

### DIFF
--- a/src/types/planets.ts
+++ b/src/types/planets.ts
@@ -94,9 +94,9 @@ export interface Planet extends PlanetBase {
   // Planet orbital properties (orbital.ts)
   getMeanLongitude: QuantityInDegreeAtJulianDayWithEquinoxFunction
   getEccentricity: QuantityAtJulianDayFunction
-  getInclination: QuantityInDegreeAtJulianDayFunction
-  getLongitudeOfAscendingNode: QuantityInDegreeAtJulianDayFunction
-  getLongitudeOfPerihelion: QuantityInDegreeAtJulianDayFunction
+  getInclination: QuantityInDegreeAtJulianDayWithEquinoxFunction
+  getLongitudeOfAscendingNode: QuantityInDegreeAtJulianDayWithEquinoxFunction
+  getLongitudeOfPerihelion: QuantityInDegreeAtJulianDayWithEquinoxFunction
   // Extended planet base properties (details.ts)
   getAphelion: JulianDayForJulianDayFunction
   getPerihelion: JulianDayForJulianDayFunction


### PR DESCRIPTION
I noticed that a few of the type definitions are slightly wrong - `getInclination`, `getLongitudeOfAscendingNode`, and `getLongitudeOfAscendingNode` all have the optional equinox parameter, but the type definitions don't reflect that.