### PR TITLE
Fix Rise, Transit, Set times near spring equinox

### DIFF
--- a/src/risetransitset/accurate.ts
+++ b/src/risetransitset/accurate.ts
@@ -9,6 +9,54 @@ import { getDeltaT } from '@/times'
 import { getDeltaMTimes } from './deltamtimes'
 import { getMTimes, MTimes } from './mtimes'
 import { getJDatUTC } from './utils'
+import { fmod360 } from '@/utils'
+
+/** @private */
+/**
+ * Adjusts a sequence of three equatorial coordinates' right ascensions for interpolation,
+ * ensuring continuity across the 0h/24h boundary, per AA 2ed pg 30 "Important Remark 2"
+ * notes for interpolation, 
+ *
+ * **This function modifies the input array in place** 
+ * 
+ * > As remarked in PJ Naughter's release notes for  -  an RA sequence must account for the jump to 0h at 24 hours
+ * The solution here, based on soln from AA+ v1.36 & v1.79, assumes
+ * - the coords are in chronological order, jd-1, jd, jd+1
+ * - that the true ra step is <= 12 hours (true for most astronomical objects)
+ *
+ * @param {LengthArray<EquatorialCoordinates, 3>} eqCoords 
+ */
+function correctCoordsForInterpolation(eqCoords: LengthArray<EquatorialCoordinates, 3>) {
+  
+  let ra1 = fmod360(eqCoords[0].rightAscension)
+  let ra2 = fmod360(eqCoords[1].rightAscension)
+  let ra3 = fmod360(eqCoords[2].rightAscension)
+  let changed = false
+  function unwrapCoords(alpha1: number, alpha2: number) {
+    if (Math.abs(alpha2 - alpha1) <= 180) return [alpha1, alpha2]
+    changed = true
+    if (alpha2 > alpha1) {
+      alpha1 += 360
+    } else {
+      alpha2 += 360
+    }
+    return [alpha1, alpha2]
+  }
+  
+  [ra1, ra2] = unwrapCoords(ra1, ra2);
+  [ra2, ra3] = unwrapCoords(ra2, ra3);
+  if (!changed) return; // don't do the loop again if we don't need to
+  // need to run again, because ra2 may have
+  // shifted relative to the others
+  [ra1, ra2] = unwrapCoords(ra1, ra2);
+  [ra2, ra3] = unwrapCoords(ra2, ra3);
+  
+  // modify the coordinates inplace
+  eqCoords[0].rightAscension = ra1
+  eqCoords[1].rightAscension = ra2
+  eqCoords[2].rightAscension = ra3
+  
+}
 
 
 /**
@@ -57,6 +105,8 @@ export function getAccurateRiseTransitSetTimes (jd: JulianDay,
       }
     }
   }
+  
+  correctCoordsForInterpolation(equCoords)
   
   // Getting the UT 0h on day D. See AA p.102.
   const jd0 = getJulianDayMidnight(jd)

--- a/tests/risetransitset.test.js
+++ b/tests/risetransitset.test.js
@@ -171,4 +171,26 @@ describe('rise transit & sets', () => {
     expect(resultsManual.rise.julianDay).toEqual(resultsSun.rise.julianDay)
     expect(resultsManual.transit.julianDay).toEqual(resultsSun.transit.julianDay)
   })
+
+  test('accurate sun rise transit set at equator on 2025 March 20', () => {
+    const geoCoords = { longitude: 0, latitude: 0, altitude: 0 }
+    const date = new Date(Date.UTC(2025, 2, 20, 9, 1, 0))
+    const jd = juliandays.getJulianDay(date)
+    const jd0 = juliandays.getJulianDayMidnightDynamicalTime(jd)
+
+    const coords0 = Sun.getApparentGeocentricEquatorialCoordinates(jd0 - 1)
+    const coords1 = Sun.getApparentGeocentricEquatorialCoordinates(jd0)
+    const coords2 = Sun.getApparentGeocentricEquatorialCoordinates(jd0 + 1)
+    const results = getAccurateRiseTransitSetTimes(jd, [coords0, coords1, coords2], geoCoords, -0.8333, 2)
+    
+
+    expect(coords1.rightAscension).toBeCloseTo(359.652359867422, 2)
+    expect(coords1.declination).toBeCloseTo( -0.15092212633498955, 2)
+    expect(results.rise.utc).toBeCloseTo(6.0684, 1)
+    expect(results.transit.utc).toBeCloseTo( 12.1227, 1)
+    expect(results.set.utc).toBeCloseTo(18.1767759, 1)
+    expect(results.transit.isCircumpolar).toBeFalsy()
+    expect(results.transit.isAboveHorizon).toBeTruthy()
+    expect(results.transit.isAboveAltitude).toBeTruthy()
+  })
 })


### PR DESCRIPTION
A bug occurs in `getAccurateRiseTransitSetTimes` when an object's right ascension wraps from 360 to 0 degrees. The interpolation requires that the values be monotonic. This PR implements the solution referenced in `CAARiseTransitSet` in AA+ v1.36 & v1.79, by adjusting the RA sequence to be monotonic. This bug affects 1-2 days a year for the Sun, and is even rarer for the outer planets

The test added to `risetransitset.test.js` fails before the change, but passes afterwards. The test uses the Sun, but the problem/solution is general to planets too. The true values come from [this python script](https://gist.github.com/johnarban/5b255e4685c93202c192ae6353b5099f) which uses the `Skyfield` library